### PR TITLE
Update reqs and check notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We can see that using Featuretools allows us to acheive better results. Featuret
 
     #### Mac OS
     ```
-    brew install gcc@5 --without-multilib
+    brew install libomp
     pip install -r requirements.txt
     ```
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-featuretools>=0.6.0
+featuretools>=0.16.0
 jupyter>=1.0.0
 scikit-learn>=0.20.2
 xgboost>=0.81


### PR DESCRIPTION
Bump featuretools version to 0.16.0 and verify notebooks still run. Also updated installation instructions for Mac as old instructions to run `brew install gcc@5 --without-multilib` resulted in an error.